### PR TITLE
Bump to 0.16.3 and add myself as maintainer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.15.1" %}
+{% set version = "0.16.3" %}
 
 package:
     name: metakernel
@@ -7,7 +7,7 @@ package:
 source:
     fn: metakernel-{{ version }}.tar.gz
     url: https://pypi.io/packages/source/m/metakernel/metakernel-{{ version }}.tar.gz
-    sha256: ba459d64353898f2f2fbd5cc43c63b068e3aa479b99c465fda782e9e4ee6e7cc
+    sha256: bfd3fcd0b996f2179b09eec6a473add232a46172fe214017614e92a3b69f0c0b
 
 build:
     number: 0
@@ -40,3 +40,4 @@ extra:
         - ocefpaf
         - ericdill
         - mariusvniekerk
+        - blink1073


### PR DESCRIPTION
@dsblank, I added https://github.com/Calysto/metakernel/commit/abad8c369d34dea6710286b546803e3ae28c9eb9 to make it easier to update this recipe when we make a release.

The setup would be to fork this repo.

After each release, we make a PR that updates the `version` and `sha256` fields in this recipe, as I have done here.

If you agree, I'll add you to the list of maintainers as well.