### PR TITLE
Try and get metakernel to build on windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: bfd3fcd0b996f2179b09eec6a473add232a46172fe214017614e92a3b69f0c0b
 
 build:
-    number: 0
+    number: 1
     script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -20,6 +20,7 @@ requirements:
     run:
         - python
         - jupyter
+        - pexpect >=4.2
         - gnureadline  # [osx]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,3 +42,4 @@ extra:
         - ericdill
         - mariusvniekerk
         - blink1073
+        - dsblank


### PR DESCRIPTION
@ocefpaf, the issue was that `pexpect` is not used on Windows by the `jupyter` package (since  `terminado` does not work on Windows), so we need to include it specifically.

@dsblank, I added you as a maintainer per your comments in #11.