### PR TITLE
Py36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - CONDA_PY=27
     - CONDA_PY=34
     - CONDA_PY=35
-
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "nDkYRseYlfn//49b6pvROH23SIHUqCgQFZrdCdcIrPQEq1/ikNUkS5RUR7jVRX59wrOH1o+JChcNkEcqW9MhB2irmTj9h5jQqOq803vDXrpxzTkCrlh7muCIgv1vVfVN2LkSs6Jd7c/s/Mnb8fTikS5bdYJ3KYqDinzdyVnwiq27Qo0suErBd1B45/fHKhkx8kkfByFx5OsPoxBBHLWTTGXgu62PJx6oEMRZiDn5MBqfopxWkZtHYXrnZRstGYTAoJXsmym7mQeGdu4+AkXuVKN+Hxl7Y++Scf1kROjBouz/VD6PkuwyM+PerpHNMNjnR+JW9ENKKGroe5KAg1Q+tzyMWNos0u1ddr2xkujn411RZxaxzQ1mCh6axc8iP1Tz6NH1YCpIcEcyW0FsAEGhld2/FWRjozct0/850iIe0p4qCqd7av8lV6MWXl0dVKHSBT/x8BzasqrJzHlpOar1ojbVmLD97R+VTZqz646qSW89HVL4EscdS8sBL9EPgwgTe1moiw8EV6i5dxegr5iiEKY86uLEEjcf0XWsDDH+zoBHEEk33+YUwD1PhB4eH5X7GxPM4hcYYud+QtIz00WF+ABn7tDuG7WDzmBo1pRB5JUm3D3YYCH2FEppKYaVe0TtNCOlQshg72ypQPIAEe6pAdoNVQDKMdnyPBSbnMV7bdo="
@@ -32,6 +32,8 @@ install:
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
       conda config --add channels conda-forge
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: Metakernel for Jupyter.
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/metakernel-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/metakernel-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/metakernel-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/metakernel-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/metakernel-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/metakernel-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/metakernel/badges/version.svg)](https://anaconda.org/conda-forge/metakernel)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/metakernel/badges/downloads.svg)](https://anaconda.org/conda-forge/metakernel)
+
 Installing metakernel
 =====================
 
@@ -66,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/metakernel-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/metakernel-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/metakernel-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/metakernel-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/metakernel-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/metakernel-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/metakernel/badges/version.svg)](https://anaconda.org/conda-forge/metakernel)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/metakernel/badges/downloads.svg)](https://anaconda.org/conda-forge/metakernel)
 
 
 Updating metakernel-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,6 @@ environment:
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
-  CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
-
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -43,6 +38,14 @@ environment:
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.
@@ -63,23 +66,20 @@ install:
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
 
-    # Add our channels.
-    - cmd: set "OLDPATH=%PATH%"
+    # Add path, activate `conda` and update conda.
     - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --add channels conda-forge
-
-    # Add a hack to switch to `conda` version `4.1.12` before activating.
-    # This is required to handle a long path activation issue.
-    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: conda install --yes --quiet conda=4.1.12
-    - cmd: set "PATH=%OLDPATH%"
-    - cmd: set "OLDPATH="
-
-    # Actually activate `conda`.
+    - cmd: conda update --yes --quiet conda
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+
     - cmd: set PYTHONUNBUFFERED=1
 
+    # Add our channels.
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --remove channels defaults
+    - cmd: conda config --add channels defaults
+    - cmd: conda config --add channels conda-forge
+
+    # Configure the VM.
     - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,7 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
- - defaults # As we need conda-build
+ - defaults
 
 conda-build:
  root-dir: /feedstock_root/build_artefacts
@@ -25,8 +25,8 @@ CONDARC
 )
 
 cat << EOF | docker run -i \
-                        -v ${RECIPE_ROOT}:/recipe_root \
-                        -v ${FEEDSTOCK_ROOT}:/feedstock_root \
+                        -v "${RECIPE_ROOT}":/recipe_root \
+                        -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit $?
@@ -56,6 +56,12 @@ source run_conda_forge_build_setup
 
     set -x
     export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - setuptools
   run:
     - python
-    - jupyter
+    - ipykernel
     - pexpect >=4.2
     - gnureadline  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,45 +1,45 @@
 {% set version = "0.17.4" %}
 
 package:
-    name: metakernel
-    version: {{ version }}
+  name: metakernel
+  version: {{ version }}
 
 source:
-    fn: metakernel-{{ version }}.tar.gz
-    url: https://pypi.io/packages/source/m/metakernel/metakernel-{{ version }}.tar.gz
-    sha256: d7e07706144d0705de7426cd282a426cecfddcb65b5231ab04287a53b5edc35e
+  fn: metakernel-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/m/metakernel/metakernel-{{ version }}.tar.gz
+  sha256: d7e07706144d0705de7426cd282a426cecfddcb65b5231ab04287a53b5edc35e
 
 build:
-    number: 0
-    script: python setup.py install --single-version-externally-managed --record record.txt
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
-    build:
-        - python
-        - setuptools
-    run:
-        - python
-        - jupyter
-        - pexpect >=4.2
-        - gnureadline  # [osx]
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - jupyter
+    - pexpect >=4.2
+    - gnureadline  # [osx]
 
 test:
-    imports:
-        - metakernel
-        - metakernel.magics
-        - metakernel.magics.tests
-        - metakernel.tests
-        - metakernel.utils
+  imports:
+    - metakernel
+    - metakernel.magics
+    - metakernel.magics.tests
+    - metakernel.tests
+    - metakernel.utils
 
 about:
-    home: https://github.com/Calysto/metakernel
-    license: BSD 3-Clause
-    summary: 'Metakernel for Jupyter.'
+  home: https://github.com/Calysto/metakernel
+  license: BSD 3-Clause
+  summary: 'Metakernel for Jupyter.'
 
 extra:
-    recipe-maintainers:
-        - ocefpaf
-        - ericdill
-        - mariusvniekerk
-        - blink1073
-        - dsblank
+  recipe-maintainers:
+    - ocefpaf
+    - ericdill
+    - mariusvniekerk
+    - blink1073
+    - dsblank


### PR DESCRIPTION
@blink1073, based on https://github.com/conda-forge/metakernel-feedstock/pull/14#issuecomment-271113132 I change the dependency from the `jupyter` metapackage (curently only unavailable for PY36) to `ipykernel`, which is already available.

Is that OK?